### PR TITLE
add zh-CN, update ar & pl-PL and fix l10n bug

### DIFF
--- a/coffee/_l10n.coffee
+++ b/coffee/_l10n.coffee
@@ -40,8 +40,14 @@ class L10n
     )
     return result
 
-  get: (l10nId, params) ->
-    translatedString = @cachedStrings[@currentLang][l10nId]
+  get: (l10nId, params, fallbackToEn) ->
+    lang = @currentLang
+
+    # We may not find new-added string, so let's fallback to english
+    if fallbackToEn
+      lang = 'en'
+
+    translatedString = @cachedStrings[lang][l10nId]
 
     reBracket = /\{\{\s*(\w+)\s*\}\}/g
     matched = false
@@ -58,7 +64,10 @@ class L10n
     translate() while matched = reBracket.exec(translatedString)
 
     if not translatedString
-      throw new Error('You are accessing non-existent l10nId : ' + l10nId)
+      console.log("""
+        You are accessing non-existent l10nId : #{l10nId}, lang: #{@currentLang}
+      """)
+      return @get(l10nId, params, true)
     else
       return translatedString
 

--- a/coffee/_menubar.coffee
+++ b/coffee/_menubar.coffee
@@ -32,7 +32,8 @@ changeLang = (menuItem, lang) ->
   { label: 'Português', lang: 'pt-BR' },
   { label: 'Български', lang: 'bg' },
   { label: 'Nederlands', lang: 'nl' },
-  { label: 'العربية', lang: 'ar' }
+  { label: 'العربية', lang: 'ar' },
+  { label: '简体中文', lang: 'zh-CN' }
 ].forEach((item) ->
   label = item.label
   lang = item.lang

--- a/l10n/ar.ini
+++ b/l10n/ar.ini
@@ -1,34 +1,34 @@
 # UI
-search = بحث
-top_track = أعلى المقوطعات
-featured_artist = الفنان المميز
-history = السجل
-new_playlist = قائمة تشغيل جديدة
+search = " بحث"
+top_track = " أعلى المقوطعات"
+featured_artist = " الفنان المميز"
+history = " السجل"
+new_playlist = " قائمة تشغيل جديدة"
 
 # Dialogue / Popups
-create_playlist_popup = أدخل اسم لقائمة التشغيل الجديدة
-rename_playlist_popup = عيّن اسماً جديداً
-update_version_popup =  تتوفر نسخة جديدة من أتراكي، بالضغط على نعم، ستُحول إلى موقعنا حيث يمكنك تنزيل النسخة الأحدث. مالجديد؟
-delete_playlist_popup = هل ترغب في حذف قائمة التشغيل؟
+create_playlist_popup = " أدخل اسم لقائمة التشغيل الجديدة"
+rename_playlist_popup = " عيّن اسماً جديداً"
+update_version_popup = "  تتوفر نسخة جديدة من أتراكي، بالضغط على نعم، ستُحول إلى موقعنا حيث يمكنك تنزيل النسخة الأحدث. مالجديد؟"
+delete_playlist_popup = " هل ترغب في حذف قائمة التشغيل؟"
 
 # Sorting
-sort_by = رتب حسب
-sort_by_default = الإفتراضي
-sort_by_track = المقطوعة
-sort_by_artist = الفنان
+sort_by = " رتب حسب"
+sort_by_default = " الإفتراضي"
+sort_by_track = " المقطوعة"
+sort_by_artist = " الفنان"
 
 # Hints when hovering on elements
-hint_previous_song = السابق
-hint_next_song = التالي
-hint_pause = ألبث
-hint_play = تشغيل
-hint_shuffle = عشوائي
-hint_repeat = أعد المقطوعة
-hint_full_screen = كامل الشاشة
-hint_minimize_window = تصغير النافذة
-hint_expand_window = تكبير النافذة
-hint_close_window = إغلاف النافذة
+hint_previous_song = " السابق"
+hint_next_song = " التالي"
+hint_pause = " ألبث"
+hint_play = " تشغيل"
+hint_shuffle = " عشوائي"
+hint_repeat = " أعد المقطوعة"
+hint_full_screen = " كامل الشاشة"
+hint_minimize_window = " تصغير النافذة"
+hint_expand_window = " تكبير النافذة"
+hint_close_window = " إغلاف النافذة"
 
 # Context Menus
-context_menu_add_to_playlist = أضف إلى {{playlist}}
-context_menu_remove_from_plalist = أزِل من {{playlist}}
+context_menu_add_to_playlist = " أضف إلى {{playlist}}"
+context_menu_remove_from_plalist = " أزِل من {{playlist}}"

--- a/l10n/pl-PL.ini
+++ b/l10n/pl-PL.ini
@@ -22,11 +22,11 @@ hint_previous_song = "Poprzedni"
 hint_next_song = "Następny"
 hint_pause = "Pauza"
 hint_play = "Play"
-hint_shuffle = "Losuj"
+hint_shuffle = "Losowo"
 hint_repeat = "Powtarzaj utwór"
 hint_full_screen = "Pełny ekran"
 hint_minimize_window = "Minimalizuj"
-hint_expand_window = "Losuj"
+hint_expand_window = "Maksymalizuj"
 hint_close_window = "Zamknij"
 
 # Context Menus

--- a/l10n/zh-CN.ini
+++ b/l10n/zh-CN.ini
@@ -1,0 +1,34 @@
+# UI
+search = " 搜索"
+top_track = "热门歌曲"
+featured_artist = "热门艺人"
+history = "历史"
+new_playlist = "新建播放列表"
+
+# Dialogue / Popups
+create_playlist_popup = "输入新播放列表名称"
+rename_playlist_popup = "设置新名称"
+update_version_popup = "Atraci有新版本啦。点击OK将跳转到最新版本的下载页面。更新了什么呢？"
+delete_playlist_popup = "您确定要删除这个播放列表吗？"
+
+# Sorting
+sort_by = "排序"
+sort_by_default = "默认"
+sort_by_track = "歌曲"
+sort_by_artist = "艺人"
+
+# Hints when hovering on elements
+hint_previous_song = "上一首"
+hint_next_song = "下一首"
+hint_pause = "暂停"
+hint_play = "播放"
+hint_shuffle = "乱序播放"
+hint_repeat = "重复播放"
+hint_full_screen = "全屏"
+hint_minimize_window = "最小化"
+hint_expand_window = "最大化"
+hint_close_window = "关闭"
+
+# Context Menus
+context_menu_add_to_playlist = "添加至{{playlist}}"
+context_menu_remove_from_plalist = "从{{playlist}}中移除"


### PR DESCRIPTION
1. add zh-CN language
2. update at & pl-PL languages
3. fix an l10n bug. If users are using languages other than en.ini, there might be chances that current language doesn't have this related key because the whole process would take time in getLocalization.com. In this way, we will fallback to en.ini directly to show en strings instead of make the application broken.
