### PR TITLE
Installer: Use lzma2/ultra for compression

### DIFF
--- a/dist/win/windows-installer.iss
+++ b/dist/win/windows-installer.iss
@@ -44,7 +44,7 @@ UninstallFilesDir={app}
 ShowLanguageDialog=no
 
 ; Compress the files nicely
-Compression=lzma2
+Compression=lzma2/ultra
 SolidCompression=yes
 
 ; Final Installer


### PR DESCRIPTION
- Thanks to this we're able to remove 1.92 MB (2018268 bytes) from installer
- Note: this way memory usage is increased from from 95MB to 372MB
  http://www.jrsoftware.org/ishelp/index.php?topic=setup_compression

![total_commander_2014-08-25_12-48-29](https://cloud.githubusercontent.com/assets/80596/4028944/38615662-2c46-11e4-9f5a-fed4e412f916.png)
